### PR TITLE
Added XMP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Deflickered
 *.PNG
 *.tiff
 *.TIFF
+.*.swp
 /blib/
 /.build/
 _build/

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -175,6 +175,7 @@ sub luminance_change {
     if ( !-d "Deflickered" ) {
       mkdir("Deflickered") || die "Error creating directory: $!\n";
     }
+    #TODO: Create directory name with timestamp to avoid overwriting previous work.
 
     debug("Changing brightness of $luminance{$i}{filename} and saving to the destination directory...\n");
     my $image = Image::Magick->new;

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -35,7 +35,11 @@ my $Passes        = 1;
 
 #####################
 # handle flags and arguments
-# Example: c == "-c", c: == "-c argument"
+# h is "help" (no arguments)
+# v is "verbose" (no arguments)
+# d is "debug" (no arguments)
+# w is "rolling window size" (single numeric argument)
+# p is "passes" (single numeric argument)
 my $opt_string = 'hvdw:p:';
 getopts( "$opt_string", \my %opt ) or usage() and exit 1;
 

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -24,6 +24,7 @@ use Image::Magick;
 use Data::Dumper;
 use File::Type;
 use Term::ProgressBar;
+use Image::ExifTool qw(:Public);
 
 #use File::Spec;
 
@@ -84,7 +85,10 @@ if ( scalar @files != 0 ) {
     if ( $filetype eq "image" ) {
       verbose("Original luminance of Image $filename is being processed...\n");
 
+      #Create ImageMagick object for the image
       my $image = Image::Magick->new;
+      #Create exifTool object for the image
+      my $exifTool = new Image::ExifTool;
       $image->Read($filename);
       #$image->Gamma(gamma => 2.2, channel => 'All');
       my @statistics = $image->Statistics();
@@ -102,11 +106,11 @@ if ( scalar @files != 0 ) {
       # We use the following formula to get the perceived luminance
       $luminance{$count}{original} = 0.299 * $R + 0.587 * $G + 0.114 * $B;
 
-      #$luminance{$count}{original} = 0.2126 * $R + 0.7152 * $G + 0.0722 * $B;
       $luminance{$count}{value}    = $luminance{$count}{original};
       $luminance{$count}{filename} = $filename;
 
-      #$luminance{$count}{abs_path_filename} = File::Spec->rel2abs($filename);
+      #$exifTool->SetNewValue(Author => "Joe Author" ); #TODO: Create and set custom tag instead of author tag
+      #$exifTool->WriteInfo(undef, $filename . ".xmp", 'XMP'); #Write the XMP file
       $count++;
     }
 

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -99,12 +99,10 @@ if ( scalar @files != 0 ) {
 
 my $max_entries = scalar( keys %luminance );
 
-if ( $max_entries < 2 ) { die "Cannot process less than two files.\n" } else {
-  say "$max_entries image files to be processed.";
-  say "Original luminance of Images is being calculated";
-  say "Please be patient as this might take several minutes...";
-}
+if ( $max_entries < 2 ) { die "Cannot process less than two files.\n" }
 
+say "$max_entries image files to be processed.";
+say "Original luminance of Images is being calculated";
 #Determine luminance of each file and add to the hash.
 luminance_det();
 

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -34,6 +34,25 @@ my $DEBUG         = 0;
 my $RollingWindow = 15;
 my $Passes        = 1;
 
+#Define namespace and tag for luminance, to be used in the XMP files.
+%Image::ExifTool::UserDefined::luminance = (
+    GROUPS => { 0 => 'XMP', 1 => 'XMP-luminance', 2 => 'Image' },
+    NAMESPACE => { 'luminance' => 'https://github.com/cyberang3l/timelapse-deflicker' }, #Sort of semi stable reference?
+    WRITABLE => 'string',
+    luminance => {}
+);
+
+%Image::ExifTool::UserDefined = (
+    # new XMP namespaces (ie. XMP-xxx) must be added to the Main XMP table:
+    'Image::ExifTool::XMP::Main' => {
+        luminance => {
+            SubDirectory => {
+                TagTable => 'Image::ExifTool::UserDefined::luminance'
+            },
+        },
+    }
+);
+
 #####################
 # handle flags and arguments
 # h is "help" (no arguments)
@@ -152,7 +171,7 @@ sub luminance_det {
     my $exifTool = new Image::ExifTool;
     #Write luminance info to an xmp file.
     #in progress: testing xmp in/out
-    $exifTool->SetNewValue(Author => $luminance{$i}{value}); #TODO: Create and set custom tag instead of author tag
+    $exifTool->SetNewValue(luminance => $luminance{$i}{value}); 
     $exifTool->WriteInfo(undef, $luminance{$i}{filename} . ".xmp", 'XMP'); #Write the XMP file
     $progress->update( $i + 1 );
   }

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -156,11 +156,13 @@ sub luminance_det {
     #If there's already an xmp file for this filename, read it.
     if (-e $luminance{$i}{filename}.".xmp") { 
       $exifinfo = $exifTool->ImageInfo($luminance{$i}{filename}.".xmp");
+      debug("Found xmp file: $luminance{$i}{filename}.xmp\n")
     }
     #Now, if it already has a luminance value, just use that:
     if ( length $$exifinfo{Luminance} ) {
       # Set it as the original and target value to start out with.
       $luminance{$i}{value} = $luminance{$i}{original} = $$exifinfo{Luminance};
+      debug("Read luminance $$exifinfo{Luminance} from xmp file: $luminance{$i}{filename}.xmp\n")
     }
     else {
       #Create ImageMagick object for the image
@@ -179,10 +181,17 @@ sub luminance_det {
       # Set it as the original and target value to start out with.
       $luminance{$i}{value} = $luminance{$i}{original} = 0.299 * $R + 0.587 * $G + 0.114 * $B;
 
-      #Write luminance info to an xmp file.  TODO: This fails if there is already an xmp file for this image.
+      #Write luminance info to an xmp file.
       #This is the xmp for the input file, so it contains the original luminance.
       $exifTool->SetNewValue(luminance => $luminance{$i}{original}); 
-      $exifTool->WriteInfo(undef, $luminance{$i}{filename} . ".xmp", 'XMP'); #Write the XMP file
+      #If there is already an xmp file, just update it:
+      if (-e $luminance{$i}{filename}.".xmp") { 
+        $exifTool->WriteInfo($luminance{$i}{filename} . ".xmp")
+      }
+      #Otherwise, create a new one:
+      else {
+        $exifTool->WriteInfo(undef, $luminance{$i}{filename} . ".xmp", 'XMP'); #Write the XMP file
+      }
     }
     $progress->update( $i + 1 );
   }

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -170,16 +170,7 @@ sub luminance_change {
 
     my $brightness = ( 1 / ( $luminance{$i}{original} / $luminance{$i}{value} ) ) * 100;
 
-    # Debug gamma and other imagemagick functions on command line:
-    #    convert DSC_8400.JPG -gamma 1 jpg:- | display jpg:-
-    #    convert DSC_8400.JPG -colorspace Gray -gamma 2.2 jpg:- | display jpg:-
-    #    convert DSC_8400.JPG -colorspace Gray -gamma 2.2 jpg:- | identify -verbose jpg:-
-    #    convert DSC_8400.JPG -format "%[gamma]\n" info:
-    #my $gamma = (1 / ( $luminance{$i}{original} / $luminance{$i}{value} ));
-
     debug("Imagemagick will set brightness of $luminance{$i}{filename} to: $brightness\n");
-
-    #debug("Imagemagick will set gamma value of $luminance{$i}{filename} to: $gamma\n");
 
     if ( !-d "Deflickered" ) {
       mkdir("Deflickered") || die "Error creating directory: $!\n";
@@ -191,7 +182,6 @@ sub luminance_change {
 
     $image->Mogrify( 'modulate', brightness => $brightness );
 
-    #$image->Gamma( gamma => $gamma, channel => 'All' );
     $image->Write( "Deflickered/" . $luminance{$i}{filename} );
 
     $progress->update( $i + 1 );

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -91,13 +91,9 @@ if ( scalar @files != 0 ) {
       my $exifTool = new Image::ExifTool;
       $image->Read($filename);
       my @statistics = $image->Statistics();
-      # Use the command "identify -verbose DSC_8400.JPG" in order to see why $R, $G and $B
+      # Use the command "identify -verbose <some image file>" in order to see why $R, $G and $B
       # are read from the following index in the statistics array
       # This is the average R, G and B for the whole image.
-      #for(my $i = 0; $i < scalar(@statistics); $i++){
-      #  print($statistics[$i] . "\n");
-      #}
-      #exit(0);
       my $R          = @statistics[ ( 0 * 7 ) + 3 ];
       my $G          = @statistics[ ( 1 * 7 ) + 3 ];
       my $B          = @statistics[ ( 2 * 7 ) + 3 ];

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -90,7 +90,6 @@ if ( scalar @files != 0 ) {
       #Create exifTool object for the image
       my $exifTool = new Image::ExifTool;
       $image->Read($filename);
-      #$image->Gamma(gamma => 2.2, channel => 'All');
       my @statistics = $image->Statistics();
       # Use the command "identify -verbose DSC_8400.JPG" in order to see why $R, $G and $B
       # are read from the following index in the statistics array

--- a/timelapse-deflicker.pl
+++ b/timelapse-deflicker.pl
@@ -54,8 +54,9 @@ $DEBUG         = 1         if $opt{'d'};
 $RollingWindow = $opt{'w'} if defined( $opt{'w'} );
 $Passes        = $opt{'p'} if defined( $opt{'p'} );
 
-die "The rolling average window for luminance smoothing should be a positive number greater or equal to 2" if ( $RollingWindow < 2 );
-die "The number of passes should be a positive number greater or equal to 1"                               if ( $Passes < 1 );
+#This integer test fails on "+n", but that isn't serious here.
+die "The rolling average window for luminance smoothing should be a positive number greater or equal to 2" if ! ($RollingWindow eq int( $RollingWindow ) && $RollingWindow > 1 ) ;
+die "The number of passes should be a positive number greater or equal to 1"                               if ! ($Passes eq int( $Passes ) && $Passes > 0 ) ;
 
 # main program content
 my %luminance;


### PR DESCRIPTION
This fork includes the following modifications:
- Split out the initial analysis of the images into a loop with a progress bar, just like the other steps.
- Warn the user if there is more than one type of image file in the directory: this is almost certainly a mistake.
- use [ExifTool](http://www.sno.phy.queensu.ca/~phil/exiftool/) to do the following:
  - Define a custom EXIF tag for luminance (the closest standard tag I could find was for brightness, which is the [APEX](https://en.wikipedia.org/wiki/APEX_system) brightness.
  - Store the calculated luminance in an xmp sidecar for each image - if there already is an xmp sidecar, add the luminance tag to it.
  - Check whether there is a luminance value defined in an existing xmp file before calculating it - this saves lots of time when reprocessing files.
- Some minor code cleanup - should all be benign, I hope: 
  - Removed some dead, commented-out code; presumably from when you were testing the script and working with gamma correction instead of ImageMagick's brightness adjustment.
  - Check for valid commandline arguments
  - Don't re-define max-entries in each processing loop
